### PR TITLE
Meta track

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,50 @@ import {Player} from "webvtt-player"
   transcript="https://example.org/transcript.vtt" />
 ```
 
+### OHMS Metadata Track
+
+*webvtt-player* can also display a WebVTT metadata track. The metadata object is modeled
+after the [OHMS Indexing system](http://ohda.matrix.msu.edu/2014/11/indexing-interviews-in-ohms/).
+
+Fields supported:
+
+```json
+{
+  "title": "",
+  "title_alt": "",
+  "synopsis": "",
+  "synopsis_alt": "",
+  "keywords": "",
+  "keywords_alt": "",
+  "subjects": "",
+  "subjects_alt": "",
+  "gpspoints": {
+    "gps": "00.0000000, 00.0000000",
+    "gps_zoom": "0",
+    "gps_text": "",
+    "gps_text_alt": ""
+  },
+  "hyperlinks": {
+    "hyperlink": "http://example.org",
+    "hyperlink_text": "",
+    "hyperlink_text_alt":, ""
+  }
+}
+```
+
+`gpspoints` will be displayed as a link to Google Maps and `hyperlinks` will be displayed as a link.
+
+The metadata track can be loaded with the `metadata` parameter.
+
+```javascript
+import {Player} from "webvtt-player"
+
+<Player
+  audio="https://example.org/audio.mp3"
+  transcript="https://example.org/transcript.vtt"
+  metadata="https://example.org/metadata.vtt" />
+```
+
 ### Demo
 
     npm install
@@ -38,12 +82,13 @@ import {Player} from "webvtt-player"
 You can use webvtt-player outside of a React project if you use the built
 JavaScript bundle from the [latest release](https://github.com/umd-mith/webvtt-player/releases) directly in the browser. Simply
 provide an anchor element with the id `webvtt-player` and use `data-audio` and
-`data-transcript` attributes to point to the audio and transcript files:
+`data-transcript` attributes to point to the audio and transcript files (`data-metadata` is optional):
 
 ```html
 <div id="webvtt-player"
      data-audio="audio.mp3"
-     data-transcript="transcript.vtt" />
+     data-transcript="transcript.vtt"
+     data-metadata="metadata.vtt" />
 ```
 
 You should be able to find the latest build as part of the webvtt demo site:

--- a/example/annotations.html
+++ b/example/annotations.html
@@ -4,9 +4,9 @@
   <head>
     <title>webvtt-player</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="style.css"> 
+    <link rel="stylesheet" href="style.css">
   </head>
-  <body>
+  <body class="with-annotations">
     <header>
       webvtt-player
       <a href="https://github.com/umd-mith/webvtt-player"><img width="149" height="149" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png?resize=149%2C149" className="" alt="Fork me on GitHub" data-recalc-dims="1"></a>
@@ -16,13 +16,17 @@
       <br />
       <a href="https://www.youtube.com/watch?v=6TlcPRlau2Q&t=557s">2016 Nobel Lecture in Literature</a> by <a href="https://en.wikipedia.org/wiki/Bob_Dylan">Bob Dylan</a>
     </p> 
+    
     <p>
       audio: <a href="data/audio.mp3">audio.mp3</a><br>
-      transcript: <a href="data/transcript.vtt">transcript.vtt</a>
+      transcript: <a href="data/transcript.vtt">transcript.vtt</a><br>
+      metadata: <a href="data/metadata.vtt">metadata.vtt</a>
     </p>
+
     <p>
-      <a href="annotations.html"><button>With Metadata</button></a>
+      <a href="index.html"><button>Without Metadata</button></a>
     </p>
-      <div id="webvtt-player" data-audio="data/audio.mp3" data-transcript="data/transcript.vtt"</div>
+
+    <div id="webvtt-player" class="annotations" data-audio="data/audio.mp3" data-transcript="data/transcript.vtt" data-metadata="data/metadata.vtt"></div>
   </body>
 </html>

--- a/example/data/metadata.vtt
+++ b/example/data/metadata.vtt
@@ -1,0 +1,21 @@
+WEBVTT
+
+Introduction
+00:00:05.000 --> 00:00:05.000
+{"keywords_alt": "", "gpspoints": {"gps_zoom": "11", "gps_text_alt": "", "gps_text": "Stockholm, Sweden", "gps": "59.3388502,18.0616981"}, "synopsis": "", "subjects": "", "hyperlinks": {"hyperlink_text_alt": "", "hyperlink_text": "", "hyperlink": ""}, "synopsis_alt": "", "title": "Introduction", "keywords": "Inspiration, Folk, Grammar School", "title_alt": "", "subjects_alt": ""}
+
+Moby Dick
+00:06:27.000 --> 00:06:27.000
+{"keywords_alt": "", "gpspoints": {"gps_zoom": "", "gps_text_alt": "", "gps_text": "", "": ""}, "synopsis": "", "subjects": "", "hyperlinks": {"hyperlink_text_alt": "", "hyperlink_text": "Wikipedia", "hyperlink": "https://en.wikipedia.org/wiki/Moby-Dick"}, "synopsis_alt": "", "title": "Moby Dick", "keywords": "allegory, religion, interpretation", "title_alt": "", "subjects_alt": ""}
+
+All Quiet on the Western Front
+00:12:36.000 --> 00:12:36.000
+{"keywords_alt": "", "gpspoints": {"gps_zoom": "", "gps_text_alt": "", "gps_text": "", "gps": ""}, "synopsis": "", "subjects": "", "hyperlinks": {"hyperlink_text_alt": "", "hyperlink_text": "Wikipedia", "hyperlink": "https://en.wikipedia.org/wiki/All_Quiet_on_the_Western_Front"}, "synopsis_alt": "", "title": "All Quiet on the Western Front", "keywords": "horror, warfare, indefferent nature, “You Ain’t Talkin’ to Me”", "title_alt": "", "subjects_alt": ""}
+
+The Odyssey
+00:20:14.000 --> 00:20:14.000
+{"keywords_alt": "", "gpspoints": {"gps_zoom": "", "gps_text_alt": "", "gps_text": "", "gps": ""}, "synopsis": "", "subjects": "", "hyperlinks": {"hyperlink_text_alt": "", "hyperlink_text": "Wikipedia", "hyperlink": "https://en.wikipedia.org/wiki/Odyssey"}, "synopsis_alt": "", "title": "The Odyssey", "keywords": "wandering, travel, mistakes", "title_alt": "", "subjects_alt": ""}
+
+Conclusion
+00:24:05.000 --> 00:24:05.000
+{"keywords_alt": "", "gpspoints": {"gps_zoom": "", "gps_text_alt": "", "gps_text": "", "gps": ""}, "synopsis": "", "subjects": "", "hyperlinks": {"hyperlink_text_alt": "", "hyperlink_text": "", "hyperlink": ""}, "synopsis_alt": "", "title": "Conclusions", "keywords": "song, immortality, performance", "title_alt": "", "subjects_alt": ""}

--- a/example/index.html
+++ b/example/index.html
@@ -62,6 +62,6 @@
       <a href="https://www.youtube.com/watch?v=6TlcPRlau2Q&t=557s">2016 Nobel Lecture in Literature</a> by <a href="https://en.wikipedia.org/wiki/Bob_Dylan">Bob Dylan</a>
     </p> 
 
-    <div id="webvtt-player" data-audio="data/audio.mp3" data-transcript="data/transcript.vtt"></div>
+    <div id="webvtt-player" data-audio="data/audio.mp3" data-transcript="data/transcript.vtt" data-metadata="data/metadata.vtt"></div>
   </body>
 </html>

--- a/example/index.js
+++ b/example/index.js
@@ -8,6 +8,7 @@ ReactDOM.render(
   <Player
     audio={root.dataset.audio}
     transcript={root.dataset.transcript}
+    metadata={root.dataset.metadata}
     preload={true} />,
   root
 )

--- a/example/style.css
+++ b/example/style.css
@@ -1,0 +1,46 @@
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  margin-left: auto;
+  margin-right: auto;
+  width: 600px;
+}
+
+body.with-annotations {
+  width: 800px;
+}
+
+header {
+  font-size: 30pt;
+  font-weight: bold;
+  text-align: center;
+  margin-bottom: 10px;
+}
+
+header a {
+  display: none;
+  position: fixed;
+  top: 0;
+  right: 0;
+}
+
+p {
+  text-align: center; 
+}
+
+p a {
+  color: black;
+}
+
+hr {
+  border: 0;
+  height: 1px;
+  background-image: linear-gradient(to right, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.75), rgba(0, 0, 0, 0));
+}
+
+button {
+  background-color: lightgreen;
+}
+
+.with-annotations button {
+  background-color: pink;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "webvtt-player",
-  "version": "0.0.11",
+  "version": "0.0.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/Metadata.js
+++ b/src/Metadata.js
@@ -1,21 +1,20 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import TranscriptLine from './TranscriptLine'
+import MetadataPoint from './MetadataPoint'
 import './Track.css'
 
-class Transcript extends React.Component {
+class Metadata extends React.Component {
 
   render() {
     const lines = []
     if (this.props.track && this.props.track.cues) {
       for (let i = 0; i < this.props.track.cues.length; i++) {
         lines.push(
-          <TranscriptLine
-            key={`line-${i}`}
+          <MetadataPoint
+            key={`point-${i}`}
             cue={this.props.track.cues[i]} 
             active={false} 
-            seek={this.props.seek} 
-            query={this.props.query} />
+            seek={this.props.seek} />
         )
       }
     }
@@ -28,11 +27,10 @@ class Transcript extends React.Component {
 
 }
 
-Transcript.propTypes = {
+Metadata.propTypes = {
   track: PropTypes.object,
   url: PropTypes.string,
-  seek: PropTypes.func,
-  query: PropTypes.string
+  seek: PropTypes.func
 }
 
-export default Transcript
+export default Metadata

--- a/src/MetadataPoint.css
+++ b/src/MetadataPoint.css
@@ -1,0 +1,37 @@
+.webvtt-player .point {
+  padding: 5px;
+}
+
+.webvtt-player .time {
+  width: 110px;
+  float: left;
+  font-size: 10pt;
+  line-height: 14pt;
+  cursor: pointer;
+}
+
+.webvtt-player .text {
+  margin-left: 110px;
+}
+
+.webvtt-player .title {
+  font-weight: bold;
+  font-size: inherit;
+  margin: 0;
+  cursor: pointer;
+}
+
+.webvtt-player .titleAlt {
+  font-style: italic;
+  font-weight: normal;
+  font-size: inherit;
+  margin: 0;
+}
+
+.webvtt-player .field {
+  margin-top: 5px;
+}
+
+.webvtt-player .field span {
+  font-style: italic;
+}

--- a/src/MetadataPoint.js
+++ b/src/MetadataPoint.js
@@ -1,0 +1,112 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import './MetadataPoint.css'
+
+class MetadataPoint extends React.Component {
+
+  constructor(props) {
+    super(props)
+    this.onClick = this.onClick.bind(this)
+  }
+
+  render() {
+    const data = JSON.parse(this.props.cue.text)
+    const titleAlt = data.title_alt
+      ? <h3 className="titleAlt">{data.title_alt}</h3>
+      : ""
+    const synopsis = data.synopsis
+      ? <div className="field">
+          <span>Synopsis</span>
+          {data.synopsis}
+        </div>
+      : ""
+    const synopsisAlt = data.synopsis_alt
+      ? <div>{data.synopsis_alt}</div>
+      : ""
+    const keywords = data.keywords
+      ? <div className="field">
+          <span>Keywords: </span>
+          {data.keywords}
+        </div>
+      : ""
+    const keywordsAlt = data.keywords_alt
+      ? <div className="field">
+          <span>Alternative Keywords: </span>
+          {data.keywords_alt}
+        </div>
+      : ""
+    const subjects = data.subjects
+      ? <div className="field">
+          <span>Subjects: </span>
+          {data.subjects}
+        </div>
+      : ""
+    const subjectsAlt = data.subjects_alt
+      ? <div className="field">
+          <span>Alternative Subjects: </span>
+          {data.subjects_alt}
+        </div>
+      : ""
+    const gpsLink = data.gpspoints.gps
+      ? <div className="field">
+          <span>Geo: </span>
+          <a href={`https://www.google.com/maps/@?api=1&map_action=map&center=${data.gpspoints.gps}&zoom=${data.gpspoints.gps_zoom}`}>{data.gpspoints.gps_text}</a>
+        </div>
+      : ""
+    const hyperlinks = data.hyperlinks.hyperlink_text
+      ? <div className="field">
+          <span>Links: </span>
+          <a href={data.hyperlinks.hyperlink}>{data.hyperlinks.hyperlink_text}</a>
+        </div>
+      : ""
+    return (
+      <div className="point">
+        <div className="time" onClick={this.onClick}>
+          [{this.startTime()}]
+        </div>
+        <div className="text">
+          <h2 className="title" onClick={this.onClick}>{data.title}</h2>
+          {titleAlt}
+          {synopsis}
+          {synopsisAlt}
+          {keywords}
+          {keywordsAlt}
+          {subjects}
+          {subjectsAlt}
+          {gpsLink}
+          {hyperlinks}
+        </div>
+      </div>
+    )
+  }
+
+  onClick() {
+    this.props.seek(this.props.cue.startTime)
+  }
+
+  startTime() {
+    return this.formatSeconds(this.props.cue.startTime)
+  }
+
+  formatSeconds(t) {
+    let mins = Math.floor(t / 60)
+    if (mins < 10) {
+      mins = `0${mins}`
+    }
+
+    let secs = Math.floor(t % 60)
+    if (secs < 10) {
+      secs = `0${secs}`
+    }
+
+    return `${mins}:${secs}`
+  }
+
+}
+
+MetadataPoint.propTypes = {
+  cue: PropTypes.object,
+  seek: PropTypes.func,
+}
+
+export default MetadataPoint

--- a/src/Player.css
+++ b/src/Player.css
@@ -13,6 +13,9 @@
   background-color: #ccc;
 }
 
+.webvtt-player .tracks {
+  display: flex;
+}
 
 .webvtt-player .controls {
   padding: 5px;

--- a/src/Player.js
+++ b/src/Player.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import Transcript from './Transcript'
+import Metadata from './Metadata'
 import Search from './Search'
 import './Player.css'
 
@@ -14,6 +15,7 @@ class Player extends React.Component {
       query: ''
     }
     this.track = React.createRef()
+    this.metatrack = React.createRef()
     this.audio = React.createRef()
 
     this.onLoaded = this.onLoaded.bind(this)
@@ -28,10 +30,18 @@ class Player extends React.Component {
 
   render () {
     let track = null
+    let metatrack = null
     if (this.state.loaded) {
       track = this.track.current.track
+      metatrack = this.metatrack.current.track
     }
     const preload = this.props.preload ? "true" : "false"
+    const metadata = this.props.metadata
+      ? <Metadata
+        url={this.props.metadata}
+        seek={this.seek}
+        track={metatrack} />
+      : ""
     return (
       <div className="webvtt-player">
         <div className="media">
@@ -47,13 +57,20 @@ class Player extends React.Component {
                 kind="subtitles"
                 src={this.props.transcript}
                 ref={this.track} />
+              <track default
+                kind="metadata"
+                src={this.props.metadata}
+                ref={this.metatrack} />
             </audio>
           </div>
-          <Transcript 
-            url={this.props.transcript} 
-            seek={this.seek} 
-            track={track} 
-            query={this.state.query} />
+          <div className="tracks">
+            <Transcript 
+              url={this.props.transcript} 
+              seek={this.seek} 
+              track={track} 
+              query={this.state.query} />
+            {metadata}
+          </div>
           <Search query={this.state.query} updateQuery={this.updateQuery} />
         </div>
       </div>
@@ -89,6 +106,7 @@ class Player extends React.Component {
 Player.propTypes = {
   audio: PropTypes.string,
   transcript: PropTypes.string,
+  metadata: PropTypes.string,
   preload: PropTypes.bool,
   query: PropTypes.string
 }

--- a/src/Track.css
+++ b/src/Track.css
@@ -1,0 +1,6 @@
+.webvtt-player .track {
+  flex: 6;
+  height: 90vh;
+  padding: 10px;
+  overflow-y: scroll;
+}

--- a/src/Transcript.css
+++ b/src/Transcript.css
@@ -1,5 +1,0 @@
-.webvtt-player .transcript {
-  height: 90vh;
-  padding: 10px;
-  overflow-y: scroll;
-}

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -5,9 +5,15 @@ const common = require('./webpack.config.js')
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const DashboardPlugin = require('webpack-dashboard/plugin');
 
-const htmlWebpackPlugin = new HtmlWebpackPlugin({
+const transcript = new HtmlWebpackPlugin({
     template: path.join(__dirname, "./example/index.html"),
     filename: "./index.html",
+    inlineSource: '\.(js|css)',
+})
+
+const metadata = new HtmlWebpackPlugin({
+    template: path.join(__dirname, "./example/annotations.html"),
+    filename: "./annotations.html",
     inlineSource: '\.(js|css)',
 })
 
@@ -47,7 +53,8 @@ module.exports = merge(common, {
     ]
   },
   plugins: [
-    htmlWebpackPlugin,
+    transcript,
+    metadata,
     new webpack.HotModuleReplacementPlugin(),
     new DashboardPlugin()
   ],

--- a/webpack.public.js
+++ b/webpack.public.js
@@ -20,6 +20,11 @@ module.exports = merge(common, {
       filename: path.resolve(publicDir, 'index.html'),
       inject: 'body',
     }),
+    new HtmlWebpackPlugin({
+      template: path.resolve(exampleDir, 'annotations.html'),
+      filename: path.resolve(publicDir, 'annotations.html'),
+      inject: 'body',
+    }),
     new CopyWebpackPlugin([
       {
         from: path.resolve(exampleDir, 'data'),


### PR DESCRIPTION
This PR implements a WebVTT metadata track, which is shown as a new column to the right of the transcript when a metadata VTT file is given to the Player (see screenshot below).

The supported metadata fields are derived from [OHMS indexing](http://ohda.matrix.msu.edu/2014/11/indexing-interviews-in-ohms/) metadata fields. Most are simple text fields that will be displayed when present, but two are treated as special cases: 

- `gpspoints` is rendered as a link to Google Maps
- `hyperlinks` produces a link to an external resource

To make this system more flexible and less bound to OHMS, we could consider displaying any key-value pair in the JSON metadata payload, but I think it would still be helpful to have a special case for `gpspoints` and `hyperlink` or come up with a convention specific to this player.

![Screenshot from 2020-12-14 17-32-56](https://user-images.githubusercontent.com/144770/102143803-82e0f580-3e32-11eb-9d65-5ccaf6926139.png)
